### PR TITLE
UIFC-494: Create CheckboxFilterAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for stripes-leipzig-components
 
 ## IN PROGRESS
-
+* Create component CheckboxFilterAccordion ([UIFC-494](https://folio-org.atlassian.net/browse/UIFC-494))
 
 ## [1.0.0](https://github.com/folio-org/stripes-leipzig-components/tree/v1.0.0) (2026-04-15)
 * Add basic files and structure

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+export { default as CheckboxFilterAccordion } from './lib/CheckboxFilterAccordion';
 export { default as EditCard } from './lib/EditCard';
 export { default as Monthpicker } from './lib/Monthpicker';
 export { default as NoPermissionMessage } from './lib/NoPermissionMessage';

--- a/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.js
+++ b/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+
+import {
+  Accordion,
+  FilterAccordionHeader,
+} from '@folio/stripes/components';
+import { CheckboxFilter } from '@folio/stripes/smart-components';
+
+const CheckboxFilterAccordion = ({
+  activeFilters = {},
+  dataOptions = [],
+  filterHandlers,
+  filterKey,
+  label,
+  ...props
+}) => {
+  const groupFilters = activeFilters[filterKey] || [];
+
+  return (
+    <Accordion
+      displayClearButton={groupFilters.length > 0}
+      header={FilterAccordionHeader}
+      id={`filter-accordion-${filterKey}`}
+      label={label}
+      onClearFilter={() => { filterHandlers.clearGroup(filterKey); }}
+      separator={false}
+      {...props}
+    >
+      <CheckboxFilter
+        dataOptions={dataOptions}
+        name={filterKey}
+        onChange={(group) => { filterHandlers.state({ ...activeFilters, [group.name]: group.values }); }}
+        selectedValues={groupFilters}
+      />
+    </Accordion>
+  );
+};
+
+CheckboxFilterAccordion.propTypes = {
+  activeFilters: PropTypes.object,
+  dataOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.node,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  })).isRequired,
+  filterHandlers: PropTypes.shape({
+    clearGroup: PropTypes.func.isRequired,
+    state: PropTypes.func.isRequired,
+  }).isRequired,
+  filterKey: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+};
+
+export default CheckboxFilterAccordion;

--- a/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.test.js
+++ b/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.test.js
@@ -1,3 +1,5 @@
+import { FormattedMessage } from 'react-intl';
+
 import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
@@ -53,6 +55,14 @@ describe('CheckboxFilterAccordion', () => {
     expect(state).toHaveBeenCalledWith({ status: ['active', 'inactive'] });
   });
 
+  test('calls the state handler without the unchecked option', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Active' }));
+
+    expect(state).toHaveBeenCalledWith({ status: [] });
+  });
+
   test('keeps the other active filter groups untouched', async () => {
     renderComponent({ activeFilters: { status: [], type: ['journal'] } });
 
@@ -73,6 +83,35 @@ describe('CheckboxFilterAccordion', () => {
     renderComponent({ activeFilters: {} });
 
     expect(screen.queryByRole('button', { name: /clearFilterSetLabel/ })).not.toBeInTheDocument();
+  });
+
+  test('renders all options unchecked if activeFilters is omitted', () => {
+    renderComponent({ activeFilters: undefined });
+
+    expect(screen.getByRole('checkbox', { name: 'Active' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Inactive' })).not.toBeChecked();
+    expect(screen.queryByRole('button', { name: /clearFilterSetLabel/ })).not.toBeInTheDocument();
+  });
+
+  test('adds the checked option to an empty filter group', async () => {
+    renderComponent({ activeFilters: undefined });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Active' }));
+
+    expect(state).toHaveBeenCalledWith({ status: ['active'] });
+  });
+
+  test('renders an empty accordion if the filter group has no options', () => {
+    renderComponent({ dataOptions: [] });
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  test('accepts a node as label', () => {
+    renderComponent({ label: <FormattedMessage id="ui-my-module.filter.status" /> });
+
+    expect(screen.getByRole('button', { name: /ui-my-module.filter.status/ })).toBeInTheDocument();
   });
 
   test('passes further props on to the accordion', () => {

--- a/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.test.js
+++ b/lib/CheckboxFilterAccordion/CheckboxFilterAccordion.test.js
@@ -1,0 +1,83 @@
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import renderWithIntlConfiguration from '../../test/jest/helpers/renderWithIntlConfiguration';
+import CheckboxFilterAccordion from './CheckboxFilterAccordion';
+
+const clearGroup = jest.fn();
+const state = jest.fn();
+
+const dataOptions = [
+  { label: 'Active', value: 'active' },
+  { label: 'Inactive', value: 'inactive' },
+];
+
+const LABEL = 'Status';
+
+const renderComponent = (props = {}) => renderWithIntlConfiguration(
+  <CheckboxFilterAccordion
+    activeFilters={{ status: ['active'] }}
+    dataOptions={dataOptions}
+    filterHandlers={{ clearGroup, state }}
+    filterKey="status"
+    label={LABEL}
+    {...props}
+  />
+);
+
+describe('CheckboxFilterAccordion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders the label and all data options', () => {
+    renderComponent();
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Inactive' })).toBeInTheDocument();
+  });
+
+  test('checks the options of the active filter group', () => {
+    renderComponent();
+
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Inactive' })).not.toBeChecked();
+  });
+
+  test('calls the state handler with the changed group', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Inactive' }));
+
+    expect(state).toHaveBeenCalledWith({ status: ['active', 'inactive'] });
+  });
+
+  test('keeps the other active filter groups untouched', async () => {
+    renderComponent({ activeFilters: { status: [], type: ['journal'] } });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Active' }));
+
+    expect(state).toHaveBeenCalledWith({ status: ['active'], type: ['journal'] });
+  });
+
+  test('calls the clear handler for the filter group', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: /clearFilterSetLabel/ }));
+
+    expect(clearGroup).toHaveBeenCalledWith('status');
+  });
+
+  test('renders no clear button if the group has no active filters', () => {
+    renderComponent({ activeFilters: {} });
+
+    expect(screen.queryByRole('button', { name: /clearFilterSetLabel/ })).not.toBeInTheDocument();
+  });
+
+  test('passes further props on to the accordion', () => {
+    renderComponent({ closedByDefault: true });
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/lib/CheckboxFilterAccordion/README.md
+++ b/lib/CheckboxFilterAccordion/README.md
@@ -1,0 +1,63 @@
+# CheckboxFilterAccordion
+
+A checkbox filter group for search panes: renders an [Accordion](https://github.com/folio-org/stripes-components/tree/main/lib/Accordion) together with a [CheckboxFilter](https://github.com/folio-org/stripes-smart-components/tree/main/lib/SearchAndSort/components/CheckboxFilter) and wires both to the `activeFilters` and `filterHandlers` of `SearchAndSortQuery`. The accordion shows a clear button as soon as the group has an active filter.
+
+
+## Usage
+
+```js
+import { CheckboxFilterAccordion } from '@folio/stripes-leipzig-components';
+
+<CheckboxFilterAccordion />
+
+```
+
+
+## Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`activeFilters` | object | All active filters of the search pane, keyed by filter group. | `{}` | false
+`dataOptions` | array | The options of this filter group, each `{ label, value }`. | `[]` | true
+`filterHandlers` | object | The filter handlers of `SearchAndSortQuery`; `clearGroup` and `state` are used. | - | true
+`filterKey` | string | Name of the filter group, e.g. `status`. Also builds the accordion id `filter-accordion-${filterKey}`. | - | true
+`label` | node | Label of the accordion, already translated. | - | true
+
+All further props are passed on to the underlying `Accordion`, e.g. `closedByDefault`.
+
+
+## CheckboxFilterAccordion example
+
+```
+  const statusOptions = [
+    { value: 'active', label: <FormattedMessage id="ui-my-module.filter.status.active" /> },
+    { value: 'inactive', label: <FormattedMessage id="ui-my-module.filter.status.inactive" /> },
+  ];
+
+  const typeOptions = [
+    { value: 'journal', label: <FormattedMessage id="ui-my-module.filter.type.journal" /> },
+    { value: 'book', label: <FormattedMessage id="ui-my-module.filter.type.book" /> },
+  ];
+
+  <SearchAndSortQuery {...}>
+    {({ activeFilters, getFilterHandlers }) => (
+      <AccordionSet>
+        <CheckboxFilterAccordion
+          activeFilters={activeFilters.state}
+          dataOptions={statusOptions}
+          filterHandlers={getFilterHandlers()}
+          filterKey="status"
+          label={<FormattedMessage id="ui-my-module.filter.status" />}
+        />
+        <CheckboxFilterAccordion
+          activeFilters={activeFilters.state}
+          closedByDefault
+          dataOptions={typeOptions}
+          filterHandlers={getFilterHandlers()}
+          filterKey="type"
+          label={<FormattedMessage id="ui-my-module.filter.type" />}
+        />
+      </AccordionSet>
+    )}
+  </SearchAndSortQuery>
+
+```

--- a/lib/CheckboxFilterAccordion/index.js
+++ b/lib/CheckboxFilterAccordion/index.js
@@ -1,0 +1,1 @@
+export { default } from './CheckboxFilterAccordion';


### PR DESCRIPTION
[UIFC-494](https://folio-org.atlassian.net/browse/UIFC-494)

### Description

Create component `CheckboxFilterAccordion` in `stripes-leipzig-component`.

There are duplicates of the function `renderCheckboxFilter`:
https://github.com/search?q=org%3Afolio-org%20renderCheckboxFilter&type=code 
The goal is to create a component that all apps can import and that eliminates the redundancy of this function. 

### Approach

- Extracts the `renderCheckboxFilter` helper duplicated across nine filter components into one shared component: `Accordion` + `FilterAccordionHeader` wrapping a `CheckboxFilter`.
- Takes `dataOptions` instead of `filterState + key`
- Does not resolve translation ids: label comes in already translated
- `PropTypes` mirror `CheckboxFilter`: `dataOptions` is required, `activeFilters` is optional.
- Forwarding further props to the `Accordion`, e.g. closedByDefault.
- Add tests and README