### PR TITLE
UIFC-498: Create component DynamicSelectionFilterAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Create component CheckboxFilterAccordion ([UIFC-494](https://folio-org.atlassian.net/browse/UIFC-494))
+* Create component DynamicSelectionFilterAccordion ([UIFC-498](https://folio-org.atlassian.net/browse/UIFC-498))
 
 ## [1.0.0](https://github.com/folio-org/stripes-leipzig-components/tree/v1.0.0) (2026-04-15)
 * Add basic files and structure

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { default as CheckboxFilterAccordion } from './lib/CheckboxFilterAccordion';
+export { default as DynamicSelectionFilterAccordion } from './lib/DynamicSelectionFilterAccordion';
 export { default as EditCard } from './lib/EditCard';
 export { default as Monthpicker } from './lib/Monthpicker';
 export { default as NoPermissionMessage } from './lib/NoPermissionMessage';

--- a/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.js
+++ b/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.js
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types';
+
+import {
+  Accordion,
+  FilterAccordionHeader,
+  Selection,
+} from '@folio/stripes/components';
+
+const DynamicSelectionFilterAccordion = ({
+  activeFilters = {},
+  dataOptions = [],
+  filterHandlers,
+  filterKey,
+  label,
+  // a blank keeps the height of the selection control if nothing is selected
+  placeholder = ' ',
+  ...props
+}) => {
+  const groupFilters = activeFilters[filterKey] || [];
+
+  return (
+    <Accordion
+      displayClearButton={groupFilters.length > 0}
+      header={FilterAccordionHeader}
+      id={`filter-accordion-${filterKey}`}
+      label={label}
+      onClearFilter={() => { filterHandlers.clearGroup(filterKey); }}
+      separator={false}
+      {...props}
+    >
+      <Selection
+        dataOptions={dataOptions}
+        id={`${filterKey}-filter`}
+        onChange={(value) => { filterHandlers.state({ ...activeFilters, [filterKey]: value ? [value] : [] }); }}
+        placeholder={placeholder}
+        value={groupFilters[0] || ''}
+      />
+    </Accordion>
+  );
+};
+
+DynamicSelectionFilterAccordion.propTypes = {
+  activeFilters: PropTypes.object,
+  dataOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  })).isRequired,
+  filterHandlers: PropTypes.shape({
+    clearGroup: PropTypes.func.isRequired,
+    state: PropTypes.func.isRequired,
+  }).isRequired,
+  filterKey: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  placeholder: PropTypes.node,
+};
+
+export default DynamicSelectionFilterAccordion;

--- a/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.js
+++ b/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.js
@@ -12,7 +12,6 @@ const DynamicSelectionFilterAccordion = ({
   filterHandlers,
   filterKey,
   label,
-  // a blank keeps the height of the selection control if nothing is selected
   placeholder = ' ',
   ...props
 }) => {

--- a/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.test.js
+++ b/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.test.js
@@ -1,0 +1,141 @@
+import { FormattedMessage } from 'react-intl';
+
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import renderWithIntlConfiguration from '../../test/jest/helpers/renderWithIntlConfiguration';
+import DynamicSelectionFilterAccordion from './DynamicSelectionFilterAccordion';
+
+const clearGroup = jest.fn();
+const state = jest.fn();
+
+const dataOptions = [
+  { label: 'Source A', value: 'source-a' },
+  { label: 'Source B', value: 'source-b' },
+];
+
+const LABEL = 'Metadata source';
+
+const renderComponent = (props = {}) => renderWithIntlConfiguration(
+  <DynamicSelectionFilterAccordion
+    activeFilters={{ mdSource: ['source-a'] }}
+    dataOptions={dataOptions}
+    filterHandlers={{ clearGroup, state }}
+    filterKey="mdSource"
+    label={LABEL}
+    {...props}
+  />
+);
+
+// the selection renders its control as a button holding the label of the selected option
+const getSelection = () => document.getElementById('mdSource-filter');
+
+const openSelection = () => userEvent.click(getSelection());
+
+describe('DynamicSelectionFilterAccordion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders the label and all data options', async () => {
+    renderComponent();
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toBeInTheDocument();
+
+    await openSelection();
+
+    expect(screen.getByRole('option', { name: 'Source A' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Source B' })).toBeInTheDocument();
+  });
+
+  test('shows the option of the active filter group', () => {
+    renderComponent();
+
+    expect(getSelection()).toHaveTextContent('Source A');
+  });
+
+  test('calls the state handler with the selected value', async () => {
+    renderComponent();
+
+    await openSelection();
+    await userEvent.click(screen.getByRole('option', { name: 'Source B' }));
+
+    expect(state).toHaveBeenCalledWith({ mdSource: ['source-b'] });
+  });
+
+  test('keeps the other active filter groups untouched', async () => {
+    renderComponent({ activeFilters: { mdSource: [], type: ['journal'] } });
+
+    await openSelection();
+    await userEvent.click(screen.getByRole('option', { name: 'Source A' }));
+
+    expect(state).toHaveBeenCalledWith({ mdSource: ['source-a'], type: ['journal'] });
+  });
+
+  test('calls the clear handler for the filter group', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: /clearFilterSetLabel/ }));
+
+    expect(clearGroup).toHaveBeenCalledWith('mdSource');
+  });
+
+  test('renders no clear button if the group has no active filters', () => {
+    renderComponent({ activeFilters: {} });
+
+    expect(screen.queryByRole('button', { name: /clearFilterSetLabel/ })).not.toBeInTheDocument();
+  });
+
+  test('renders no option as selected if activeFilters is omitted', () => {
+    renderComponent({ activeFilters: undefined });
+
+    expect(getSelection()).not.toHaveTextContent('Source A');
+    expect(screen.queryByRole('button', { name: /clearFilterSetLabel/ })).not.toBeInTheDocument();
+  });
+
+  test('adds the selected value to an empty filter group', async () => {
+    renderComponent({ activeFilters: undefined });
+
+    await openSelection();
+    await userEvent.click(screen.getByRole('option', { name: 'Source A' }));
+
+    expect(state).toHaveBeenCalledWith({ mdSource: ['source-a'] });
+  });
+
+  test('renders an empty selection if the filter group has no options', async () => {
+    renderComponent({ dataOptions: [] });
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toBeInTheDocument();
+
+    await openSelection();
+
+    // the selection falls back to its empty message
+    expect(screen.getByRole('option')).toHaveTextContent('--');
+    expect(screen.queryByRole('option', { name: 'Source A' })).not.toBeInTheDocument();
+  });
+
+  test('shows the placeholder as long as no option is selected', () => {
+    renderComponent({ activeFilters: undefined, placeholder: 'Select a contact' });
+
+    expect(getSelection()).toHaveTextContent('Select a contact');
+  });
+
+  test('hides the placeholder once an option is selected', () => {
+    renderComponent({ placeholder: 'Select a contact' });
+
+    expect(getSelection()).toHaveTextContent('Source A');
+    expect(getSelection()).not.toHaveTextContent('Select a contact');
+  });
+
+  test('accepts a node as label', () => {
+    renderComponent({ label: <FormattedMessage id="ui-my-module.filter.mdSource" /> });
+
+    expect(screen.getByRole('button', { name: /ui-my-module.filter.mdSource/ })).toBeInTheDocument();
+  });
+
+  test('passes further props on to the accordion', () => {
+    renderComponent({ closedByDefault: true });
+
+    expect(screen.getByRole('button', { name: new RegExp(LABEL) })).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.test.js
+++ b/lib/DynamicSelectionFilterAccordion/DynamicSelectionFilterAccordion.test.js
@@ -27,9 +27,7 @@ const renderComponent = (props = {}) => renderWithIntlConfiguration(
   />
 );
 
-// the selection renders its control as a button holding the label of the selected option
 const getSelection = () => document.getElementById('mdSource-filter');
-
 const openSelection = () => userEvent.click(getSelection());
 
 describe('DynamicSelectionFilterAccordion', () => {

--- a/lib/DynamicSelectionFilterAccordion/README.md
+++ b/lib/DynamicSelectionFilterAccordion/README.md
@@ -1,0 +1,53 @@
+# DynamicSelectionFilterAccordion
+
+A single-select filter group for search panes, meant for filter values that are loaded dynamically (e.g. from okapi) instead of being defined in a static filter config. It renders an [Accordion](https://github.com/folio-org/stripes-components/tree/main/lib/Accordion) together with a [Selection](https://github.com/folio-org/stripes-components/tree/main/lib/Selection) and wires both to the `activeFilters` and `filterHandlers` of `SearchAndSortQuery`. The accordion shows a clear button as soon as the group has an active filter.
+
+The filter group is stored as an array like all other filter groups, but only ever holds the one selected value.
+
+
+## Usage
+
+```js
+import { DynamicSelectionFilterAccordion } from '@folio/stripes-leipzig-components';
+
+<DynamicSelectionFilterAccordion />
+
+```
+
+
+## Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`activeFilters` | object | All active filters of the search pane, keyed by filter group. | `{}` | false
+`dataOptions` | array | The options of this filter group, each `{ label, value }`. The label has to be a string. | `[]` | true
+`filterHandlers` | object | The filter handlers of `SearchAndSortQuery`; `clearGroup` and `state` are used. | - | true
+`filterKey` | string | Name of the filter group, e.g. `contact`. Also builds the accordion id `filter-accordion-${filterKey}` and the selection id `${filterKey}-filter`. | - | true
+`label` | node | Label of the accordion, already translated. | - | true
+`placeholder` | node | Shown in the selection as long as no option is selected. | `' '` | false
+
+All further props are passed on to the underlying `Accordion`, e.g. `closedByDefault`.
+
+
+## DynamicSelectionFilterAccordion example
+
+```
+  const contactOptions = (filterData.contacts || []).map(contact => ({
+    value: contact.id,
+    label: contact.name,
+  }));
+
+  <SearchAndSortQuery {...}>
+    {({ activeFilters, getFilterHandlers }) => (
+      <AccordionSet>
+        <DynamicSelectionFilterAccordion
+          activeFilters={activeFilters.state}
+          dataOptions={contactOptions}
+          filterHandlers={getFilterHandlers()}
+          filterKey="contact"
+          label={<FormattedMessage id="ui-my-module.filter.contact" />}
+        />
+      </AccordionSet>
+    )}
+  </SearchAndSortQuery>
+
+```

--- a/lib/DynamicSelectionFilterAccordion/index.js
+++ b/lib/DynamicSelectionFilterAccordion/index.js
@@ -1,0 +1,1 @@
+export { default } from './DynamicSelectionFilterAccordion';


### PR DESCRIPTION
[UIFC-498](https://folio-org.atlassian.net/browse/UIFC-498)

**Description:**
- Create component `DynamicSelectionFilterAccordion` in `stripes-leipzig-component`.
- There are duplicates of the functions in `ui-finc-config` and `ui-finc-select`:
`renderContactsFilter` and `renderMetadataSourceFilter`
- The goal is to create a component that all apps can import and that eliminates the redundancy of these functions. 

**Approach:**
- Adds `DynamicSelectionFilterAccordion`: `Accordion` + `FilterAccordionHeader` wrapping a `Selection`,
the selection counterpart to `CheckboxFilterAccordion` for filter **values loaded from okapi**.
- Does not resolve translation ids: label comes in already translated
- Adds `placeholder` as a prop, since further props go to the `Accordion`. Defaults to a blank as in the original
- Forwarding further props to the Accordion, e.g. `closedByDefault`
- Add tests and README